### PR TITLE
Allow link parsing inside parentheses

### DIFF
--- a/mmd.js
+++ b/mmd.js
@@ -10,7 +10,7 @@
 	{
 		return escape(s)
 			.replace(/!\[([^\]]*)]\(([^(]+)\)/g, '<img alt="$1" src="$2">')
-			.replace(/\[([^\]]+)]\(([^(]+)\)/g, '$1'.link('$2'))
+			.replace(/\[([^\]]+)]\(([^(]+?)\)/g, '$1'.link('$2'))
 			.replace(/`([^`]+)`/g, '<code>$1</code>')
 			.replace(/(\*\*|__)(?=\S)([^\r]*?\S[*_]*)\1/g, '<strong>$2</strong>')
 			.replace(/(\*|_)(?=\S)([^\r]*?\S)\1/g, '<em>$2</em>');


### PR DESCRIPTION
For example: (Foobars should click [here](url.com). Cool stuff will happen.)

Everything after the link gets cut off in the current version of mmd.js, because we need a "?" to stop the regex from greedily eating everything after the link on the same line.