### PR TITLE
Fix "Supported features" in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,15 +19,15 @@ The input text is split into blocks separated by one or more blank lines. The ty
 
 ## Supported features
 
-* Headers # 
-* Blockquotes >
-* Ordered lists 1
-* Unordered lists *
+* Headers `#` 
+* Blockquotes `>`
+* Ordered lists `1`
+* Unordered lists `*`
 * Paragraphs
-* Links []()
-* Images ![]()
-* Inline <em> emphasis *
-* Inline <strong> emphasis **
+* Links `[]()`
+* Images `![]()`
+* Inline `<em>` emphasis `*`
+* Inline `<strong>` emphasis `**`
 
 ## Unsupported features
 


### PR DESCRIPTION
Some characters in "Supported features" will be treated as markdowns, so I use \` \` to surround those characters. So that the README.md will be displayed prettily in Github.

Here is the snapshot of the **new README.md**:
![new](https://user-images.githubusercontent.com/51704722/80235212-f9ef3100-868b-11ea-8e75-3586d21033c3.PNG)

Compared to the **old** one:
![old](https://user-images.githubusercontent.com/51704722/80235188-f196f600-868b-11ea-9a2d-e0e7c38b5fbd.PNG)

